### PR TITLE
docs: add .env.example for Modyo CLI configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,76 @@
+# =============================================================================
+# Modyo CLI Configuration
+# =============================================================================
+# Este archivo documenta las variables de entorno para el deploy con Modyo CLI.
+# Copia este archivo a .env y configura los valores según tu entorno.
+#
+# Documentación: https://docs.modyo.com/en/platform/tools/cli.html
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# REQUERIDAS
+# -----------------------------------------------------------------------------
+
+# URL del dominio de tu cuenta Modyo (sin trailing slash)
+# Ejemplo: https://mi-cuenta.modyo.cloud
+MODYO_ACCOUNT_URL=
+
+# Token de acceso para deployments
+# Generar en: Modyo Admin > Settings > API Access > Access Tokens
+MODYO_TOKEN=
+
+# -----------------------------------------------------------------------------
+# IDENTIFICACIÓN DEL SITIO (usar UNO de los dos)
+# -----------------------------------------------------------------------------
+
+# Host del sitio donde se desplegará el widget
+# Ejemplo: mi-sitio
+MODYO_SITE_HOST=
+
+# O alternativamente, ID numérico del sitio
+# MODYO_SITE_ID=
+
+# -----------------------------------------------------------------------------
+# OPCIONALES
+# -----------------------------------------------------------------------------
+
+# Nombre del widget en Modyo (identificador único)
+# Si no se especifica, usa el nombre del package.json
+MODYO_WIDGET_NAME=
+
+# Carpeta con el resultado del build
+# Default: build (Vite) o dist (otros)
+# MODYO_BUILD_DIRECTORY=build
+
+# Versión de la plataforma Modyo (8, 9 o 10)
+# Default: 10
+# MODYO_VERSION=10
+
+# -----------------------------------------------------------------------------
+# CODE SPLITTING (ZIP MODE) - IMPORTANTE PARA ESTA RAMA
+# -----------------------------------------------------------------------------
+# Esta rama usa code splitting. Configura estas variables para el deploy.
+
+# Activar modo ZIP para code splitting (REQUERIDO para esta rama)
+MODYO_ZIP=true
+
+# Archivo JS principal para modo ZIP
+# Default: main.js
+# MODYO_ZIP_ENTRY_JS=main.js
+
+# Archivo CSS principal para modo ZIP
+# Default: main.css
+# MODYO_ZIP_ENTRY_CSS=main.css
+
+# -----------------------------------------------------------------------------
+# AVANZADO
+# -----------------------------------------------------------------------------
+
+# Regex para deshabilitar procesamiento Liquid en archivos específicos
+# Útil cuando el código contiene sintaxis que conflictúa con Liquid
+# MODYO_DISABLE_LIQUID_REGEX=
+
+# =============================================================================
+# IMPORTANTE: NO commitear el archivo .env con tokens reales
+# Agregar .env a .gitignore
+# =============================================================================

--- a/README.md
+++ b/README.md
@@ -62,17 +62,25 @@ npm run dev
 
 ## Configuración de Modyo
 
-Para hacer push a Modyo, configura las variables de entorno:
+Para hacer push a Modyo:
 
-```bash
-# .env (no commitear)
-MODYO_ACCOUNT_URL=https://tu-cuenta.modyo.cloud
-MODYO_TOKEN=tu-token
-MODYO_SITE=nombre-del-sitio
-MODYO_WIDGET_NAME=nombre-del-widget
-```
+1. Copia el archivo de ejemplo:
+   ```bash
+   cp .env.example .env
+   ```
 
-Consulta la [documentación de Modyo CLI](https://docs.modyo.com/en/platform/cli) para más detalles.
+2. Configura las variables requeridas en `.env`:
+   - `MODYO_ACCOUNT_URL` - URL de tu cuenta Modyo
+   - `MODYO_TOKEN` - Token de acceso (generar en Admin > Settings > API Access)
+   - `MODYO_SITE_HOST` - Host del sitio destino
+
+3. Ejecuta el push:
+   ```bash
+   npm run push           # Solo push
+   npm run push:publish   # Push + publicar
+   ```
+
+Ver `.env.example` para todas las opciones disponibles y la [documentación de Modyo CLI](https://docs.modyo.com/en/platform/tools/cli.html) para más detalles.
 
 ## Code Splitting
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -942,9 +942,9 @@
       }
     },
     "node_modules/@dynamic-framework/ui-react": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@dynamic-framework/ui-react/-/ui-react-2.0.0.tgz",
-      "integrity": "sha512-XqtBEwGjrAzbCsWs5MIwsN1arKxsjVoQYdPDb09EE6nTVIvJSsjxrnewUczKXgA3DgP/yktZCik3cwI/O74Ypg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@dynamic-framework/ui-react/-/ui-react-2.1.1.tgz",
+      "integrity": "sha512-yt8u8DU3vqrm66AcmCFZTYh9Ox4a5YqtkZ6SOKf6h3WAAsksZZ2S9i6TzEJb8fLVx7J417jii7wnxG6a1ojINw==",
       "license": "https://github.com/dynamic-framework/dynamic-ui/blob/master/libraries/dynamic-ui-react/LICENSE.md",
       "dependencies": {
         "@floating-ui/react": "~0.27.16",
@@ -958,7 +958,7 @@
         "file-selector": "~2.1.2",
         "google-libphonenumber": "~3.2.43",
         "html2canvas": "^1.4.1",
-        "jspdf": "^3.0.3",
+        "jspdf": "^4.0.0",
         "lucide-react": "^0.553.0",
         "react-datepicker": "~8.3.0",
         "react-international-phone": "~4.6.0",
@@ -6422,9 +6422,9 @@
       }
     },
     "node_modules/jspdf": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-3.0.4.tgz",
-      "integrity": "sha512-dc6oQ8y37rRcHn316s4ngz/nOjayLF/FFxBF4V9zamQKRqXxyiH1zagkCdktdWhtoQId5K20xt1lB90XzkB+hQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.0.0.tgz",
+      "integrity": "sha512-w12U97Z6edKd2tXDn3LzTLg7C7QLJlx0BPfM3ecjK2BckUl9/81vZ+r5gK4/3KQdhAcEZhENUxRhtgYBj75MqQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",


### PR DESCRIPTION
  - Add .env.example documenting all Modyo CLI environment variables
  - Update README to reference .env.example instead of inline examples
  - Document required vs optional variables with descriptions
  - Include links to official Modyo CLI documentation