### PR TITLE
chore: update MyLink component URLs and dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6422,9 +6422,9 @@
       }
     },
     "node_modules/jspdf": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.0.0.tgz",
-      "integrity": "sha512-w12U97Z6edKd2tXDn3LzTLg7C7QLJlx0BPfM3ecjK2BckUl9/81vZ+r5gK4/3KQdhAcEZhENUxRhtgYBj75MqQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.1.0.tgz",
+      "integrity": "sha512-xd1d/XRkwqnsq6FP3zH1Q+Ejqn2ULIJeDZ+FTKpaabVpZREjsJKRJwuokTNgdqOU+fl55KgbvgZ1pRTSWCP2kQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
@@ -6434,7 +6434,7 @@
       "optionalDependencies": {
         "canvg": "^3.0.11",
         "core-js": "^3.6.0",
-        "dompurify": "^3.2.4",
+        "dompurify": "^3.3.1",
         "html2canvas": "^1.0.0-rc.5"
       }
     },

--- a/src/components/MyComponent.tsx
+++ b/src/components/MyComponent.tsx
@@ -32,7 +32,7 @@ export default function MyComponent() {
       <div className="w-100 row mt-14">
         <div className="col mb-6">
           <MyLink
-            href="https://dynamicframework.dev/docs"
+            href="https://docs.modyo.com/en/dynamic"
             icon="Book"
             title="Learn"
             description="Get started with Dynamic Framework!"
@@ -40,7 +40,7 @@ export default function MyComponent() {
         </div>
         <div className="col mb-6">
           <MyLink
-            href="https://dynamicframework.dev/theming"
+            href="https://docs.modyo.com/en/dynamic/customization/theming.html"
             icon="Brush"
             title="Themes"
             description="Learn how to create a unique look-and-feel!"
@@ -48,10 +48,10 @@ export default function MyComponent() {
         </div>
         <div className="col mb-6">
           <MyLink
-            href="https://dynamicframework.dev/components"
+            href="https://docs.modyo.com/en/dynamic/development/components.html"
             icon="Layout"
-            title="Experiences"
-            description="Explore the fully React-based templates"
+            title="Components"
+            description="Explore the fully React-based components"
           />
         </div>
       </div>


### PR DESCRIPTION
Update the URLs in the MyLink component to point to the new Modyo documentation. Upgrade jspdf to version 4.1.0 and dompurify to version 3.3.1 in the package-lock.json.