### PR TITLE
feat: add preview entry point for Vite + React ES Modules

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,6 +70,10 @@ MODYO_ZIP=true
 # Útil cuando el código contiene sintaxis que conflictúa con Liquid
 # MODYO_DISABLE_LIQUID_REGEX=
 
+# === PREVIEW (modyo-cli preview) ===
+# MODYO_LOCAL_MODULE=true
+# MODYO_ENTRY_JS=src/modyo-preview-entry.ts
+
 # =============================================================================
 # IMPORTANTE: NO commitear el archivo .env con tokens reales
 # Agregar .env a .gitignore

--- a/src/modyo-preview-entry.ts
+++ b/src/modyo-preview-entry.ts
@@ -1,0 +1,21 @@
+/**
+ * Entry point EXCLUSIVO para modyo-cli preview.
+ * NO importar desde ningún otro archivo.
+ * Los módulos /@react-refresh y /@vite/client solo existen en el dev server.
+ *
+ * Uso:
+ *   modyo-cli preview --module --entry-js src/modyo-preview-entry.ts --port 5173 ...
+ */
+
+// 1. React Fast Refresh preamble (debe ejecutarse antes de cualquier componente React)
+const RefreshRuntime = (await import('/@react-refresh')).default;
+RefreshRuntime.injectIntoGlobalHook(window);
+window.$RefreshReg$ = () => {};
+window.$RefreshSig$ = () => (type) => type;
+window.__vite_plugin_react_preamble_installed__ = true;
+
+// 2. Vite HMR client (WebSocket + error overlay)
+await import('/@vite/client');
+
+// 3. App entry point
+await import('./main');

--- a/src/modyo-preview-entry.ts
+++ b/src/modyo-preview-entry.ts
@@ -18,4 +18,4 @@ window.__vite_plugin_react_preamble_installed__ = true;
 await import('/@vite/client');
 
 // 3. App entry point
-await import('./main');
+await import('./main.tsx');

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -33,5 +33,8 @@
     "src",
     "tests/**/*",
     "tests/setup.ts",
+  ],
+  "exclude": [
+    "src/modyo-preview-entry.ts"
   ]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,15 @@ export default defineConfig({
     svgr(),
     react(),
   ],
+  server: {
+    cors: true,
+    origin: 'http://localhost:5173',
+    allowedHosts: [
+      'localhost', 
+      '127.0.0.1', 
+      '*.modyo.cloud',
+    ],
+  },
   resolve: {
     alias: {
       '@dynamic-framework/ui-react':


### PR DESCRIPTION
Añade `modyo-preview-entry.ts `como punto de entrada alternativo para `modyo-cli preview --module`. Este archivo carga React Fast Refresh y el cliente Vite HMR antes que la aplicación, que son necesarios para previsualizar proyectos Vite + React como módulos ES.

Además, como precaución, se excluye de las compilaciones de producción a través de `tsconfig.app.json` y solo se utiliza cuando se especifica explícitamente con `--entry-js.`