### PR TITLE
fix: align RepositoryTemplate header with validator + fix i18n interpolation

### DIFF
--- a/src/_examples/QueryHookTemplate.ts
+++ b/src/_examples/QueryHookTemplate.ts
@@ -6,7 +6,7 @@
  *      (convention: camelCase `use` + PascalCase entity,
  *       e.g. `useAccount.ts`, `usePolicy.ts`)
  *   2. Rename `entityKeys`/`useEntities`/etc. to your actual entity
- *   3. Point the repository import at `<entityName>` (not `_template`)
+ *   3. Point the repository import at `<EntityName>Repository` (not `_template`)
  *
  * These hooks:
  * - Wrap calls to the repository
@@ -32,7 +32,7 @@ import {
   createEntity,
   updateEntity,
   deleteEntity,
-} from '../services/repositories/<entityName>';
+} from '../services/repositories/<EntityName>Repository';
 import type { CreateEntityData, UpdateEntityData } from '../types';
 
 // ============================================

--- a/src/_examples/README.md
+++ b/src/_examples/README.md
@@ -12,7 +12,7 @@ adapt them to your widget's domain.
 | Reference file              | Destination location                       | Naming convention            |
 |-----------------------------|--------------------------------------------|------------------------------|
 | `MockTemplate.ts`           | `src/services/mocks/<entityName>.ts`       | `mockEntities` → `mock<Entity>` |
-| `RepositoryTemplate.ts`     | `src/services/repositories/<entityName>.ts`| `getEntities` → `get<Entity>` |
+| `RepositoryTemplate.ts`     | `src/services/repositories/<EntityName>Repository.ts` | `getEntities` → `get<Entity>` |
 | `QueryHookTemplate.ts`      | `src/hooks/use<EntityName>.ts`             | `useEntities` → `use<Entity>` |
 | `EntityListScreen.tsx`      | `src/screens/<EntityName>ListScreen.tsx`   | (Composes the above) |
 

--- a/src/_examples/RepositoryTemplate.ts
+++ b/src/_examples/RepositoryTemplate.ts
@@ -2,8 +2,9 @@
  * Repository Template — Reference Example
  *
  * This file is a reference scaffold. To use:
- *   1. Copy this file to `src/services/repositories/<entityName>.ts`
- *      (convention: PascalCase entity, e.g. `Account.ts`, `Policy.ts`)
+ *   1. Copy this file to `src/services/repositories/<EntityName>Repository.ts`
+ *      (convention: PascalCase entity + `Repository.ts` suffix,
+ *      e.g. `AccountRepository.ts`, `PolicyRepository.ts`)
  *   2. Rename `Entity`/`mockEntities` references to your actual entity
  *   3. Update the endpoint paths (`/entities`) to your API surface
  *   4. Adjust the mapper to translate API shape → domain shape

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -39,7 +39,7 @@
       "error": "Could not load entities"
     },
     "entityCreate": {
-      "title": "Create {{type}}",
+      "title": "Create {type}",
       "body": "Form placeholder. In a real widget this would contain inputs for the new entity."
     }
   }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -39,7 +39,7 @@
       "error": "No se pudieron cargar las entidades"
     },
     "entityCreate": {
-      "title": "Crear {{type}}",
+      "title": "Crear {type}",
       "body": "Placeholder del formulario. En un widget real esto contendría inputs para la nueva entidad."
     }
   }


### PR DESCRIPTION
## Summary

Closes #15
Closes #16

Two unrelated drifts surfaced during testing of the Modyo MCP widget generation flow (ronda 2 of Pendiente #18, 2026-05-26).

## Changes

### `src/_examples/RepositoryTemplate.ts` — header convention

The header JSDoc told developers to copy to `src/services/repositories/<entityName>.ts` with PascalCase entity (e.g. `Account.ts`). The Modyo widget validator (`@modyo/widget-validator@0.1.4`, rule `naming-conventions`, severity `error`) requires `*Repository.ts` literal suffix (regex `^[A-Z][a-zA-Z]*Repository\.ts$`). Updated the header to instruct the suffix.

### `src/locales/{en,es}.json` — i18n interpolation

The locale key `examples.entityCreate.title` used i18next's default double-brace syntax `{{type}}`. `@dynamic-framework/ui-react` overrides the interpolation delimiters to single-brace inside `configureI18n()` (`interpolation: { prefix: '{', suffix: '}' }`). Result: literal `{{type}}` rendered at runtime.

Changed both locales to single-brace.

`EntityCreateModal.tsx` itself does not need changes — the `t()` call signature is correct.

## Testing

Manual verification:
- Header: confirm new convention matches validator regex.
- Locales: load `EntityCreateModal` and verify `{type}` interpolates.

No automated test changes — these are scaffold/reference files.

## Out of scope

Test folder structure (`tests/` raíz vs `src/__tests__/`): validator's `testing-basics` rule (severity `error`) requires `tests/` at root, which the canonical satisfies. No change needed.
