### PR TITLE
fix: alinear el directorio de salida del build al default (dist)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,9 +59,9 @@ MODYO_SITE_HOST=my-site
 # Usado en: push, preview
 # MODYO_VERSION=9
 
-# Directorio que contiene el resultado del build — Default: dist (build en este proyecto)
+# Directorio que contiene el resultado del build — Default: dist
 # Usado en: push
-# MODYO_BUILD_DIRECTORY=build
+# MODYO_BUILD_DIRECTORY=dist
 
 # Nombre del script de build a ejecutar (definido en package.json) — Default: build
 # Usado en: push

--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,6 @@ yalc.lock
 .modyo
 
 # build directories
-build
 dist
 
 # modyo-cli artifacts

--- a/.modyo.example
+++ b/.modyo.example
@@ -23,10 +23,26 @@ MODYO_SITE_HOST=my-site
 
 # --- ⚙️  OPCIONALES: push ----------------------------------------------------
 
+# Versión de la plataforma Modyo (8 | 9 | 10) — Default: 9
+# Usado en: push, preview
 # MODYO_VERSION=9
-# MODYO_BUILD_DIRECTORY=build
+
+# Directorio que contiene el resultado del build — Default: dist
+# Usado en: push
+# MODYO_BUILD_DIRECTORY=dist
+
+# Nombre del script de build a ejecutar (definido en package.json) — Default: build
+# Usado en: push
 # MODYO_BUILD_COMMAND=build
+
+# Regex de archivos a excluir del bundle subido a la plataforma
+# Ejemplo: \.map$ (excluir source maps)
+# Usado en: push
 # MODYO_REGEX_EXCLUDE=
+
+# Regex para deshabilitar el procesamiento Liquid en archivos que coincidan
+# Útil cuando el widget usa sintaxis {{ }} que conflictúa con Liquid
+# Usado en: push
 # MODYO_DISABLE_LIQUID_REGEX=
 
 # --- ⚙️  OPCIONALES: push --zip (code splitting, solo Webpack) ---------------

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,1 +1,1 @@
-/build
+/dist

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ npm run test -- --coverage
 npm run build
 ```
 
-Output en `build/`:
+Output en `dist/`:
 - `main.js` - Bundle JavaScript
 - `main.css` - Estilos compilados
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,7 +6,7 @@ import tseslint from 'typescript-eslint';
 import { defineConfig, globalIgnores } from 'eslint/config';
 
 export default defineConfig([
-  globalIgnores(['dist', 'build', 'src/_examples/**']),
+  globalIgnores(['dist', 'src/_examples/**']),
   {
     files: ['**/*.{ts,tsx}'],
     extends: [

--- a/tsconfig.examples.json
+++ b/tsconfig.examples.json
@@ -9,7 +9,6 @@
   "exclude": [
     "node_modules",
     "dist",
-    "build",
     "src/modyo-preview-entry.ts",
     "src/_examples/MockTemplate.ts",
     "src/_examples/QueryHookTemplate.ts",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -37,7 +37,6 @@ export default defineConfig({
   build: {
     chunkSizeWarningLimit: 2000,
     minify: 'esbuild',
-    outDir: 'build',
     assetsDir: '',
     rollupOptions: {
       output: {


### PR DESCRIPTION
Vite sobrescribía outDir a 'build' mientras @modyo/cli push lee 'dist' por default, obligando a descomentar MODYO_BUILD_DIRECTORY en cada clon. Eliminar el override alinea ambos en 'dist' y un clon fresco buildea y pushea sin configuración extra.