### PR TITLE
feat: bake repository pattern + pin Dynamic UI to 2.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,14 @@
 {
   "name": "@dynamic-framework/dynamic-react-vite-base-template",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dynamic-framework/dynamic-react-vite-base-template",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "dependencies": {
-        "@dynamic-framework/ui-react": "^2.5.0",
+        "@dynamic-framework/ui-react": "2.6.0",
         "@tanstack/react-query": "^5.60.0",
         "axios": "^1.13.2",
         "classnames": "^2.5.1",
@@ -945,9 +945,9 @@
       }
     },
     "node_modules/@dynamic-framework/ui-react": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@dynamic-framework/ui-react/-/ui-react-2.5.1.tgz",
-      "integrity": "sha512-5xy6n0SdequTQ7uUSr9nrLLdDX3mJn6vk8WVDTwkdPlITZ9QyiBSfJ0y8etx5wInV8IyICUtKrHR45pcFjtJzg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@dynamic-framework/ui-react/-/ui-react-2.6.0.tgz",
+      "integrity": "sha512-ht/QLoQM8dARsoDEZ+w9jlMtWRNYyaR2ngrSBVB5Pk5Y2w3kSqo8LACwwmFovQsxnKJWcKBFkXxb7fnkyYZJNw==",
       "license": "https://github.com/dynamic-framework/dynamic-ui/blob/master/LICENSE.md",
       "dependencies": {
         "@floating-ui/react": "~0.27.16",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dynamic-framework/dynamic-react-vite-base-template",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "module",
   "scripts": {
     "start": "vite",
@@ -21,7 +21,7 @@
     "typecheck:examples": "tsc --noEmit -p tsconfig.examples.json"
   },
   "dependencies": {
-    "@dynamic-framework/ui-react": "^2.5.0",
+    "@dynamic-framework/ui-react": "2.6.0",
     "@tanstack/react-query": "^5.60.0",
     "axios": "^1.13.2",
     "classnames": "^2.5.1",

--- a/src/hooks/useEntities.ts
+++ b/src/hooks/useEntities.ts
@@ -1,0 +1,41 @@
+/**
+ * useEntities — canonical TanStack Query hook example.
+ *
+ * Wraps the EntityRepository so components get cache + loading/error states for
+ * free, and invalidates the list on mutations. One file per entity (useEntities,
+ * usePolicies, ...). Copy to `src/hooks/use<EntityName>.ts` and point the
+ * repository import at your `<EntityName>Repository`.
+ */
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { createEntity, getEntities } from '../services/repositories/EntityRepository';
+import type { CreateEntityData } from '../types';
+
+export const entityKeys = {
+  all: ['entities'] as const,
+  lists: () => [...entityKeys.all, 'list'] as const,
+};
+
+/**
+ * Fetch the entity list.
+ */
+export function useEntities() {
+  return useQuery({
+    queryKey: entityKeys.lists(),
+    queryFn: ({ signal }) => getEntities(signal),
+  });
+}
+
+/**
+ * Create an entity, invalidating the list on success.
+ */
+export function useCreateEntity() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: CreateEntityData) => createEntity(data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: entityKeys.lists() });
+    },
+  });
+}

--- a/src/services/mocks/entity.ts
+++ b/src/services/mocks/entity.ts
@@ -1,0 +1,28 @@
+/**
+ * Mock data for the Entity domain (example scaffold).
+ *
+ * Mocks use DOMAIN types (post-mapper), not API types, and are returned by the
+ * repository when `widgetConfig.useMocks` (vars.use-mocks) is true. Copy this
+ * file to `src/services/mocks/<entityName>.ts` and rename for your own domain.
+ */
+import type { Entity } from '../../types';
+
+export const mockEntities: Entity[] = [
+  {
+    id: '1',
+    name: 'First Entity',
+    createdAt: '2024-01-15T10:30:00Z',
+    updatedAt: '2024-02-20T14:45:00Z',
+  },
+  {
+    id: '2',
+    name: 'Second Entity',
+    createdAt: '2024-02-01T09:00:00Z',
+  },
+  {
+    id: '3',
+    name: 'Third Entity',
+    createdAt: '2024-03-10T16:20:00Z',
+    updatedAt: '2024-03-12T11:30:00Z',
+  },
+];

--- a/src/services/repositories/EntityRepository.ts
+++ b/src/services/repositories/EntityRepository.ts
@@ -25,8 +25,8 @@ export async function getEntities(signal?: AbortSignal): Promise<Entity[]> {
   if (USE_MOCKS) {
     await delay(MOCK_DELAY);
     signal?.throwIfAborted();
-    // Return a copy so callers can't mutate the shared fixture.
-    return [...mockEntities];
+    // Return independent copies so callers can't mutate the shared fixture.
+    return mockEntities.map((entity) => ({ ...entity }));
   }
 
   const response = await api.get<ApiEntity[]>('/entities', { signal });

--- a/src/services/repositories/EntityRepository.ts
+++ b/src/services/repositories/EntityRepository.ts
@@ -1,8 +1,10 @@
 /**
  * EntityRepository — canonical repository example.
  *
- * Repositories are pure functions (no internal state — that's TanStack Query's
- * job) that either return mocks or call the API depending on `USE_MOCKS`, and
+ * Repositories are stateless as far as the app is concerned — caching and
+ * loading state are TanStack Query's job. (In mock mode `createEntity` mutates
+ * the in-memory fixture below; that's a mock-only convenience, not repository
+ * state.) They return mocks or call the API depending on `USE_MOCKS`, and
  * translate API shapes into domain types. Mirrors the structure of
  * `src/services/api/`. Copy this file to
  * `src/services/repositories/<EntityName>Repository.ts` (PascalCase entity +
@@ -22,7 +24,9 @@ const MOCK_DELAY = 500; // ms
 export async function getEntities(signal?: AbortSignal): Promise<Entity[]> {
   if (USE_MOCKS) {
     await delay(MOCK_DELAY);
-    return mockEntities;
+    signal?.throwIfAborted();
+    // Return a copy so callers can't mutate the shared fixture.
+    return [...mockEntities];
   }
 
   const response = await api.get<ApiEntity[]>('/entities', { signal });

--- a/src/services/repositories/EntityRepository.ts
+++ b/src/services/repositories/EntityRepository.ts
@@ -1,0 +1,62 @@
+/**
+ * EntityRepository — canonical repository example.
+ *
+ * Repositories are pure functions (no internal state — that's TanStack Query's
+ * job) that either return mocks or call the API depending on `USE_MOCKS`, and
+ * translate API shapes into domain types. Mirrors the structure of
+ * `src/services/api/`. Copy this file to
+ * `src/services/repositories/<EntityName>Repository.ts` (PascalCase entity +
+ * `Repository.ts`) and rename for your own domain — the query hook in
+ * `src/hooks/useEntities.ts` shows how to consume it.
+ */
+import { USE_MOCKS } from '../../config/widgetConfig';
+import type { ApiEntity, CreateEntityData, Entity } from '../../types';
+import { api } from '../api/client';
+import { mockEntities } from '../mocks/entity';
+
+const MOCK_DELAY = 500; // ms
+
+/**
+ * Fetch the entity list.
+ */
+export async function getEntities(signal?: AbortSignal): Promise<Entity[]> {
+  if (USE_MOCKS) {
+    await delay(MOCK_DELAY);
+    return mockEntities;
+  }
+
+  const response = await api.get<ApiEntity[]>('/entities', { signal });
+  return response.data.map(mapToEntity);
+}
+
+/**
+ * Create an entity.
+ */
+export async function createEntity(data: CreateEntityData): Promise<Entity> {
+  if (USE_MOCKS) {
+    await delay(MOCK_DELAY);
+    const created: Entity = {
+      id: `mock-${mockEntities.length + 1}`,
+      ...data,
+      createdAt: new Date().toISOString(),
+    };
+    mockEntities.push(created);
+    return created;
+  }
+
+  const response = await api.post<ApiEntity>('/entities', data);
+  return mapToEntity(response.data);
+}
+
+function mapToEntity(apiEntity: ApiEntity): Entity {
+  return {
+    id: apiEntity.id,
+    name: apiEntity.name,
+    createdAt: apiEntity.created_at,
+    updatedAt: apiEntity.updated_at,
+  };
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/tests/hooks/useCreateEntity.test.tsx
+++ b/tests/hooks/useCreateEntity.test.tsx
@@ -1,0 +1,37 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { describe, it, expect } from 'vitest';
+
+import { useEntities, useCreateEntity } from '../../src/hooks/useEntities';
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe('useCreateEntity', () => {
+  it('invalidates the list query after a successful create', async () => {
+    const { result } = renderHook(
+      () => ({ list: useEntities(), create: useCreateEntity() }),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.list.isSuccess).toBe(true));
+    const before = result.current.list.data!.length;
+
+    await act(async () => {
+      await result.current.create.mutateAsync({ name: 'Fourth Entity' });
+    });
+
+    // onSuccess invalidates the list -> the active query refetches with the new item.
+    await waitFor(
+      () => expect(result.current.list.data).toHaveLength(before + 1),
+      { timeout: 3000 },
+    );
+  });
+});

--- a/tests/hooks/useEntities.test.tsx
+++ b/tests/hooks/useEntities.test.tsx
@@ -1,0 +1,28 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { describe, it, expect } from 'vitest';
+
+import { useEntities } from '../../src/hooks/useEntities';
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe('useEntities', () => {
+  it('loads the mocked entity list', async () => {
+    const { result } = renderHook(() => useEntities(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toHaveLength(3);
+    expect(result.current.data?.[0].name).toBe('First Entity');
+  });
+});


### PR DESCRIPTION
## Why

A widget scaffolded from this template **fails `@modyo/widget-validator` out of the box** (surfaced during the MiBanco instrumentation run). Baseline of a pristine scaffold: **96%, 4 errors**. Three are owned by this repo:

```
[Folder Structure]   ✗ Missing required folder: src/services/repositories
[Folder Structure]   ✗ Missing required folder: src/services/mocks
[Repository Pattern] ✗ repositories/ folder not found
```

(The 4th, a Testing error, is fixed in the validator repo — see release chain.)

**Principle:** the template is the source of truth for conventions; the repository pattern is *baked in* so the widget author renames/copies a working example instead of inventing one.

## What changed

### 1. Bake the repository pattern
Previously the pattern lived only in `src/_examples/` — excluded from compilation and using placeholder imports (`../mocks/<entityName>`), so it never satisfied the validator. Graduated into real, compiling files that mirror `src/services/api/` conventions:

- **`src/services/repositories/EntityRepository.ts`** — pure async functions, `USE_MOCKS` toggle, API-shape → domain mapper. No internal state.
- **`src/services/mocks/entity.ts`** — domain-typed fixture returned when `vars.use-mocks` is true.
- **`src/hooks/useEntities.ts`** — TanStack Query hook (query + mutation) consuming the repository.

Satisfies `folder-structure` (both `repositories/` and `mocks/`), `repository-pattern` (a `PascalCaseRepository.ts` exporting async fns), and `naming-conventions`.

### 2. Pin Dynamic UI to `2.6.0`
`@dynamic-framework/ui-react`: `^2.5.0` (resolved to `2.5.1`) → **exactly `2.6.0`**, to match the deployed site and the `2.6.0` token artifact. No sibling `@dynamic-framework/*` packages exist to align (styles/icons ship inside `ui-react`). Lockfile updated.

## Verification
- `npm install` clean, **0 vulnerabilities**.
- `npm run lint` → 0 errors (2 pre-existing warnings in `errorHandler.ts`, untouched).
- `npm run build` → green (tsc + vite). Minor bump `2.5.1`→`2.6.0` did **not** break anything.
- `npm test` → 10/10.
- **Joint check** — updated validator (`@modyo/widget-validator@0.2.0`, built locally) against this branch: **100% / 110 checks / 0 errors / 0 warnings**, zero hand-fixes.

## Version
`1.0.0` → **`1.1.0`** (new feature). ⚠️ Note: `package.json` was `1.0.0` while the latest git tag is `v1.0.3` — they've drifted. Suggest tagging this release **`v1.1.0`** and reconciling the two lineages.
