### PR TITLE
feat: add custom vite plugin for liquid syntax handling

### DIFF
--- a/.vite/plugins/escapeLiquidInStrings.ts
+++ b/.vite/plugins/escapeLiquidInStrings.ts
@@ -1,0 +1,24 @@
+import type { Plugin } from 'vite';
+
+/**
+ * Escapes the exact JS string literals "{{" and "}}" in the bundle output.
+ *
+ * Unicode escapes (\u007B\u007B = {{ and \u007D\u007D = }}) are:
+ *  - Transparent to JavaScript: interpreted correctly at runtime
+ *  - Invisible to Liquid: the `{{` pattern no longer exists in the source text
+ */
+export default function escapeLiquidInStrings(): Plugin {
+  return {
+    name: 'escape-liquid-in-strings',
+    apply: 'build' as const,
+    generateBundle(_options, bundle) {
+      for (const chunk of Object.values(bundle)) {
+        if (chunk.type === 'chunk' && chunk.code) {
+          chunk.code = chunk.code
+            .replace(/"\{\{"/g, '"\\u007B\\u007B"')
+            .replace(/"\}\}"/g, '"\\u007D\\u007D"');
+        }
+      }
+    },
+  };
+}

--- a/.vite/plugins/escapeLiquidInStrings.ts
+++ b/.vite/plugins/escapeLiquidInStrings.ts
@@ -1,7 +1,8 @@
 import type { Plugin } from 'vite';
 
 /**
- * Escapes the exact JS string literals "{{" and "}}" in the bundle output.
+ * Escapes the exact JS string literals "{{" and "}}" (single- or double-quoted)
+ * in the bundle output.
  *
  * Unicode escapes (\u007B\u007B = {{ and \u007D\u007D = }}) are:
  *  - Transparent to JavaScript: interpreted correctly at runtime
@@ -15,8 +16,8 @@ export default function escapeLiquidInStrings(): Plugin {
       for (const chunk of Object.values(bundle)) {
         if (chunk.type === 'chunk' && chunk.code) {
           chunk.code = chunk.code
-            .replace(/"\{\{"/g, '"\\u007B\\u007B"')
-            .replace(/"\}\}"/g, '"\\u007D\\u007D"');
+            .replace(/(["'])\{\{\1/g, '$1\\u007B\\u007B$1')
+            .replace(/(["'])\}\}\1/g, '$1\\u007D\\u007D$1');
         }
       }
     },

--- a/README.md
+++ b/README.md
@@ -137,7 +137,15 @@ Para evitar esto, el template incluye:
 - **Plugin `escapeLiquidInStrings` (`.vite/plugins/escapeLiquidInStrings.ts`)**: se ejecuta solo en `build` y escapa los literales `"{{"` y `"}}"` que queden en el bundle final (por ejemplo, texto de UI que contenga esos caracteres sin ser Liquid intencional) convirtiéndolos a `\u007B\u007B` / `\u007D\u007D`. Esto es transparente para JS pero invisible para el parser de Liquid, evitando falsos positivos al momento del renderizado en Modyo.
 
 **¿Cuándo usar cada uno?**
-- Si necesitas **leer** una variable/config que vive en el sitio Modyo (idioma, nombre del sitio, variables custom) → usa `liquidParser`.
+- Si necesitas **leer** una variable/config que vive en el sitio Modyo (idioma, nombre del sitio, variables custom), la convención del template es declararla una única vez en `src/config/widgetConfig.ts` usando `liquidParser.parse(...)` y exportarla desde ahí (como ya se hace con `SITE_LANG`, `SITE_NAME`, `VARS_CURRENCY`, etc.). El resto del código debe importar esas constantes desde `widgetConfig.ts` en vez de llamar a `liquidParser` directamente en cada archivo:
+  ```ts
+  // src/config/widgetConfig.ts
+  export const SITE_NAME = liquidParser.parse('{{site.name}}');
+
+  // en cualquier otro componente/módulo
+  import { SITE_NAME } from '../config/widgetConfig';
+  ```
+  Esto mantiene un solo punto de import de `liquidParser`, evita duplicar tags Liquid dispersos por el código y facilita ubicar/mockear todas las variables del sitio en un solo lugar. Solo importa `liquidParser` directamente si estás agregando una variable nueva a `widgetConfig.ts`.
 - Si tienes **texto estático** (traducciones, contenido) que por coincidencia contiene `{{` o `}}` y no quieres que Modyo lo interprete → el plugin ya lo resuelve automáticamente en build, no requiere acción extra. Si ves comportamientos raros con Liquid en producción que no ocurren en local, revisa primero si el string problemático pasa por alguno de estos dos mecanismos.
 
 ## Internacionalización (i18n)

--- a/README.md
+++ b/README.md
@@ -120,6 +120,61 @@ npm run test -- --watch
 npm run test -- --coverage
 ```
 
+## Manejo de Liquid
+
+Modyo procesa el contenido de un widget como una plantilla Liquid antes de servirlo, por lo que cualquier `{{ }}` o `{% %}` que aparezca "suelto" en el bundle (por ejemplo dentro de un string JS, un JSON o una clase CSS) puede ser interpretado y removido/reemplazado por el motor de Liquid del sitio, rompiendo el widget en producción.
+
+Para evitar esto, el template incluye:
+
+- **`src/config/liquid.json` + `src/utils/liquidParser.ts`**: helper que resuelve tags Liquid (`{{site.language}}`, `{{vars.mi-variable}}`, etc.) contra un mock local en desarrollo (usando `liquidjs`) y los deja pasar tal cual en producción, donde Modyo los reemplaza en el servidor. Úsalo cuando necesites leer variables o contexto del sitio (`site.*`, `vars.*`) desde el código:
+  ```ts
+  import liquidParser from '../utils/liquidParser';
+
+  const siteName = liquidParser.parse('{{site.name}}');
+  ```
+  Los valores mock para desarrollo local se configuran en `src/config/liquid.json`.
+
+- **Plugin `escapeLiquidInStrings` (`.vite/plugins/escapeLiquidInStrings.ts`)**: se ejecuta solo en `build` y escapa los literales `"{{"` y `"}}"` que queden en el bundle final (por ejemplo, texto de UI que contenga esos caracteres sin ser Liquid intencional) convirtiéndolos a `\u007B\u007B` / `\u007D\u007D`. Esto es transparente para JS pero invisible para el parser de Liquid, evitando falsos positivos al momento del renderizado en Modyo.
+
+**¿Cuándo usar cada uno?**
+- Si necesitas **leer** una variable/config que vive en el sitio Modyo (idioma, nombre del sitio, variables custom) → usa `liquidParser`.
+- Si tienes **texto estático** (traducciones, contenido) que por coincidencia contiene `{{` o `}}` y no quieres que Modyo lo interprete → el plugin ya lo resuelve automáticamente en build, no requiere acción extra. Si ves comportamientos raros con Liquid en producción que no ocurren en local, revisa primero si el string problemático pasa por alguno de estos dos mecanismos.
+
+## Internacionalización (i18n)
+
+El template usa [`i18next`](https://www.i18next.com/) junto a [`react-i18next`](https://react.dev.i18next.com/) como librería de internacionalización, integradas mediante el helper `configureI18n` de `@dynamic-framework/ui-react`.
+
+Configuración (`src/config/i18nConfig.ts`):
+
+```ts
+import { configureI18n } from '@dynamic-framework/ui-react';
+
+import en from '../locales/en.json';
+import es from '../locales/es.json';
+
+import { SITE_LANG } from './widgetConfig';
+
+const resources = {
+  es: { translation: es },
+  en: { translation: en },
+};
+
+configureI18n(resources, { lng: SITE_LANG });
+```
+
+- Las traducciones viven en `src/locales/*.json` (uno por idioma).
+- El idioma inicial se toma de `SITE_LANG` (resuelto vía Liquid desde `{{site.language}}`, ver sección anterior), de modo que el widget arranca en el idioma configurado en el sitio de Modyo.
+- Para cambiar de idioma en runtime se expone `changeLanguage(lang)` desde el mismo archivo.
+- En componentes se usa el hook estándar de `react-i18next`:
+  ```tsx
+  import { useTranslation } from 'react-i18next';
+
+  const { t } = useTranslation();
+  t('siteLang', { lang: SITE_LANG });
+  ```
+
+**Si quieres usar otra librería de i18n**, ten en cuenta que `@dynamic-framework/ui-react` expone algunos componentes que dependen internamente de `i18next`/`react-i18next` (a través de `configureI18n`), por lo que no podrás remover esas dependencias por completo. Puedes sí evitar usar `configureI18n` y `useTranslation` en tu propio código y reemplazarlos por tu librería preferida (p. ej. `react-intl`, `lingui`), inicializándola en paralelo y usándola en tus componentes; solo asegúrate de mantener sincronizado el idioma inicial con `SITE_LANG` si necesitas que ambos sistemas reflejen el idioma del sitio.
+
 ## Build de Producción
 
 ```bash

--- a/src/components/MyComponent.tsx
+++ b/src/components/MyComponent.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 
 import MyLink from './MyLink';
 import MyLogos from './MyLogos';
+import SiteLang from './SiteLang';
 
 export default function MyComponent() {
   const { t } = useTranslation();
@@ -17,6 +18,7 @@ export default function MyComponent() {
         'align-items-center justify-content-center',
       )}
     >
+      <SiteLang />
       <h1 className="fw-semibold text-center">{t('title')}</h1>
       <p className="h5 text-muted text-center py-4">
         Get started by editing

--- a/src/components/SiteLang.tsx
+++ b/src/components/SiteLang.tsx
@@ -1,12 +1,13 @@
 import { useTranslation } from 'react-i18next';
+
 import { SITE_LANG } from '../config/widgetConfig';
 
 export default function SiteLang() {
-	const { t } = useTranslation();
+  const { t } = useTranslation();
 
-	return (
-		<small className="fw-normal text-center text-muted">
-			{t('siteLang', { lang: SITE_LANG })}
-		</small>
-	)
+  return (
+    <small className="fw-normal text-center text-muted">
+      {t('siteLang', { lang: SITE_LANG })}
+    </small>
+  );
 }

--- a/src/components/SiteLang.tsx
+++ b/src/components/SiteLang.tsx
@@ -1,5 +1,5 @@
-import { useTranslation } from "react-i18next";
-import { SITE_LANG } from "../config/widgetConfig";
+import { useTranslation } from 'react-i18next';
+import { SITE_LANG } from '../config/widgetConfig';
 
 export default function SiteLang() {
 	const { t } = useTranslation();

--- a/src/components/SiteLang.tsx
+++ b/src/components/SiteLang.tsx
@@ -1,0 +1,12 @@
+import { useTranslation } from "react-i18next";
+import { SITE_LANG } from "../config/widgetConfig";
+
+export default function SiteLang() {
+	const { t } = useTranslation();
+
+	return (
+		<small className="fw-normal text-center text-muted">
+			{t('siteLang', { lang: SITE_LANG })}
+		</small>
+	)
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,5 +1,6 @@
 {
   "title": "Welcome to the Modyo Widget Template",
+  "siteLang": "This site is in: {lang}",
   "states": {
     "loading": "Loading...",
     "empty": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -1,5 +1,6 @@
 {
   "title": "Bienvenido al template de widget Modyo",
+  "siteLang": "Este sitio está en: {lang}",
   "states": {
     "loading": "Cargando...",
     "empty": {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,6 +6,7 @@ import './config/i18nConfig';
 
 import App from './App';
 
+// Comment or remove this line if your Modyo's site has already loaded the Dynamic UI CSS, otherwise it will be loaded twice and may cause style issues.
 import '@dynamic-framework/ui-react/dist/css/dynamic-ui.css';
 import './styles/base.scss';
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,7 +6,7 @@ import './config/i18nConfig';
 
 import App from './App';
 
-// Comment or remove this line if your Modyo's site has already loaded the Dynamic UI CSS, otherwise it will be loaded twice and may cause style issues.
+// Comment or remove this line if your Modyo site has already loaded the Dynamic UI CSS, otherwise it will be loaded twice and may cause style issues.
 import '@dynamic-framework/ui-react/dist/css/dynamic-ui.css';
 import './styles/base.scss';
 

--- a/tests/components/MyComponent.test.tsx
+++ b/tests/components/MyComponent.test.tsx
@@ -5,8 +5,15 @@ import MyComponent from '../../src/components/MyComponent';
 // Mock react-i18next
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
-    t: (key: string) => key,
+    t: (key: string, options?: Record<string, unknown>) => (
+      options ? `${key} ${JSON.stringify(options)}` : key
+    ),
   }),
+}));
+
+// Mock widgetConfig to control SITE_LANG in tests
+vi.mock('../../src/config/widgetConfig', () => ({
+  SITE_LANG: 'en',
 }));
 
 // Mock MyLogos component
@@ -27,6 +34,11 @@ describe('<MyComponent />', () => {
     const button = screen.getByText('Click me!');
     fireEvent.click(button);
     expect(screen.getByTestId('my-logos')).toBeInTheDocument();
+  });
+
+  it('should render the site language label with the correct interpolation params', () => {
+    render(<MyComponent />);
+    expect(screen.getByText('siteLang {"lang":"en"}')).toBeInTheDocument();
   });
 
   it('should hide logos when "Click me!" button is clicked twice', () => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,11 +3,13 @@ import react from '@vitejs/plugin-react';
 import path from 'path';
 import { defineConfig } from 'vite';
 import svgr from 'vite-plugin-svgr';
+import escapeLiquidInStrings from './.vite/plugins/escapeLiquidInStrings';
 
 export default defineConfig({
   plugins: [
     svgr(),
     react(),
+    escapeLiquidInStrings(),
   ],
   server: {
     cors: true,


### PR DESCRIPTION
Introduce a plugin to escape Liquid syntax in JavaScript strings, add a SiteLang component for displaying the current site language, and update translations accordingly. Clarify the usage of the Dynamic UI CSS import in the main file.